### PR TITLE
Workflows and tests in separate scaling

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -47,6 +47,7 @@ jobs:
         with:
           cache-version: 1
           extra-packages: |
+            stan-dev/cmdstanr
             n-kall/iwmm
             rcmdcheck
             checkmate

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,6 +34,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: r-lib/actions/setup-pandoc@v2
+
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
@@ -46,6 +47,7 @@ jobs:
         with:
           cache-version: 1
           extra-packages: |
+            n-kall/iwmm
             rcmdcheck
             checkmate
             jsonlite

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, separate_scaling]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, separate_scaling]
 
 name: R-CMD-check
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -47,6 +47,7 @@ jobs:
         with:
           cache-version: 1
           extra-packages: |
+            XML
             stan-dev/cmdstanr
             n-kall/iwmm
             rcmdcheck

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,6 +44,7 @@ jobs:
       # packages that are needed for R CMD CHECK
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          cache-version: 1
           extra-packages: |
             rcmdcheck
             checkmate

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ inst/doc
 .Rproj.user
 .Rhistory
 .Rdata
+priorsense.Rcheck
+priorsense_0.0.0.9000.tar.gz
 .httr-oauth
 .DS_Store
 docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.2
 Imports:
+    brms,
     cetcolor,
     checkmate,
     ggplot2,

--- a/R/cjs.R
+++ b/R/cjs.R
@@ -14,7 +14,7 @@
 ##'
 ##' \deqn{CJS_{dist}(P || Q) = \sqrt{CJS(P || Q) + CJS(Q || P)}}
 ##'
-##' This has an upper bound of \eqn{\sqrt \sum (P(x) + Q(x))}
+##' This has an upper bound of \eqn{\sqrt{ \sum (P(x) + Q(x))}}
 ##'
 ##' @param x numeric vector of samples from first distribution
 ##' @param y numeric vector of samples from second distribution

--- a/man/cjs_dist.Rd
+++ b/man/cjs_dist.Rd
@@ -42,7 +42,7 @@ The symmetric metric is defined as:
 
 \deqn{CJS_{dist}(P || Q) = \sqrt{CJS(P || Q) + CJS(Q || P)}}
 
-This has an upper bound of \eqn{\sqrt \sum (P(x) + Q(x))}
+This has an upper bound of \eqn{\sqrt{ \sum (P(x) + Q(x))}}
 }
 \references{
 Nguyen H-V., Vreeken J. (2015).  Non-parametric


### PR DESCRIPTION
Not complete, but feel free to merge any time.

- Set cache-version to one explicitly to enable caching (probably not necessary)
- Fetch cmdstanr and iwmm from GitHub.
- Specify XML as a dependency to avoid problems with old version