### PR TITLE
Run cmdstanr check only if installed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,10 +30,13 @@ Imports:
 Suggests:
     knitr,
     rstan,
-    cmdstanr,
     testthat (>= 3.0.0),
     rmarkdown,
     covr
+Enhancements:
+    cmdstanr
+Additional_repositories:
+    stan-dev
 Config/testthat/edition: 3
 Depends: 
     R (>= 3.6.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,8 +35,6 @@ Suggests:
     covr
 Enhancements:
     cmdstanr
-Additional_repositories:
-    stan-dev
 Config/testthat/edition: 3
 Depends: 
     R (>= 3.6.0)

--- a/tests/testthat/test_cmdstan.R
+++ b/tests/testthat/test_cmdstan.R
@@ -1,53 +1,59 @@
-## set.seed(123)
-## normal_example <- example_powerscale_model("univariate_normal")
+cmdstanr_available <- require(cmdstanr)
 
-## test_that("powerscale functions work for CmdStanFit", {
-##   skip_on_cran()
-##   cs <- cmdstanr::cmdstan_model(
-##     stan_file = cmdstanr::write_stan_file(normal_example$model_code)
-##   )
+if(cmdstanr_available) {
 
-##   cfit <- cs$sample(
-##     data = normal_example$data,
-##     refresh = 0,
-##     seed = 123,
-##     iter_sampling = 250,
-##     iter_warmup = 250,
-##     chains = 1
-##   )  
-##   expect_s3_class(
-##     create_powerscaling_data(
-##       cfit
-##     ),
-##     "powerscaling_data"
-##   )
-##   expect_s3_class(
-##     powerscale(
-##       x = cfit,
-##       component = "prior",
-##       alpha = 0.8
-##     ),
-##     "powerscaled_draws"
-##   )
-##   expect_s3_class(
-##     powerscale(
-##       x = cfit,
-##       component = "likelihood",
-##       alpha = 0.8
-##     ),
-##     "powerscaled_draws"
-##   )
-##   expect_s3_class(
-##     suppressWarnings(powerscale_sequence(
-##       x = cfit
-##     )),
-##     "powerscaled_sequence"
-##   )
-##   expect_s3_class(
-##     powerscale_sensitivity(
-##       x = cfit
-##     ),
-##     "powerscaled_sensitivity_summary"
-##   )
-## }
-## )
+set.seed(123)
+normal_example <- example_powerscale_model("univariate_normal")
+
+test_that("powerscale functions work for CmdStanFit", {
+  skip_on_cran()
+  cs <- cmdstanr::cmdstan_model(
+    stan_file = cmdstanr::write_stan_file(normal_example$model_code)
+  )
+
+  cfit <- cs$sample(
+    data = normal_example$data,
+    refresh = 0,
+    seed = 123,
+    iter_sampling = 250,
+    iter_warmup = 250,
+    chains = 1
+  )  
+  expect_s3_class(
+    create_powerscaling_data(
+      cfit
+    ),
+    "powerscaling_data"
+  )
+  expect_s3_class(
+    powerscale(
+      x = cfit,
+      component = "prior",
+      alpha = 0.8
+    ),
+    "powerscaled_draws"
+  )
+  expect_s3_class(
+    powerscale(
+      x = cfit,
+      component = "likelihood",
+      alpha = 0.8
+    ),
+    "powerscaled_draws"
+  )
+  expect_s3_class(
+    suppressWarnings(powerscale_sequence(
+      x = cfit
+    )),
+    "powerscaled_sequence"
+  )
+  expect_s3_class(
+    powerscale_sensitivity(
+      x = cfit
+    ),
+    "powerscaled_sensitivity_summary"
+  )
+}
+)
+
+}


### PR DESCRIPTION
Only run the tests in test-moment-match-cmdstan-analytical.R if CmdStanR is installed.

* Add an if guard to avoid running the tests.
* Move CmdStanR to Enhancements in DESCRIPTION. Suggestions need to be installed when running tests.
* Add the repository for CmdStanR to Additional_repositories in DESCRIPTION.

