### PR TITLE
fix issue with lower_alpha not being used for gradient calculation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+priorsense 1.0.4
+---
++ Fix an issue where `lower_alpha` was not taken into account when
+  calculating the gradient of the divergence.
+
 priorsense 1.0.3
 ---
 + Fix issue with model parameter named "alpha"

--- a/R/powerscale_gradients.R
+++ b/R/powerscale_gradients.R
@@ -325,14 +325,15 @@ powerscale_divergence_gradients <- function(lower_divergences,
 
   variable <- lower_divergences$variable
 
-  ## second-order centered difference approximation
-  ## f''(x) = (f(x + dx) - 2f(x) + f(x - dx)) / dx^2
-  ## here it is wrt log_2 alpha
   upper_diff <- subset(upper_divergences, select = -c(variable))
   lower_diff <- subset(lower_divergences, select = -c(variable))
-  logdiffsquare <- 2 * log(upper_alpha, base = 2)
-  grad <- (upper_diff + lower_diff) / logdiffsquare
 
-  return(tibble::as_tibble(cbind(variable, grad)))
+  log_upper_alpha <- log(upper_alpha, base = 2)
+  log_lower_alpha <- log(lower_alpha, base = 2)
+  grad_upper <- upper_diff / log_upper_alpha
+  grad_lower <- -1 * lower_diff / log_lower_alpha
 
+  mean_grad <- (grad_upper + grad_lower) / 2
+
+  return(tibble::as_tibble(cbind(variable, mean_grad)))
 }


### PR DESCRIPTION
Fixes an issue where lower_alpha was not taken into account when calculating the gradient. This was only an issue if the lower_alpha was specified manually.