### PR TITLE
Replaced import with importFrom for posterior::summarise_ndraws()

### DIFF
--- a/R/powerscale.R
+++ b/R/powerscale.R
@@ -93,7 +93,7 @@ powerscale.priorsense_data <- function(x,
   draws <- x$draws
 
   if (is.null(k_threshold)) {
-    k_threshold <- min(1 - 1 / log10(ndraws(draws)), 0.7)
+    k_threshold <- min(1 - 1 / log10(posterior::ndraws(draws)), 0.7)
   }
 
     # transform the draws if specified

--- a/R/priorsense-package.R
+++ b/R/priorsense-package.R
@@ -3,8 +3,7 @@
 #'
 #' @name priorsense-package
 #' @aliases priorsense
-#' @import methods
-#' @import posterior
+#' @importFrom posterior summarise_draws
 #'
 #' @description The \pkg{priorsense} package provides functions for
 #'   prior and likelihood sensitivity analysis of Bayesian


### PR DESCRIPTION
However, this causes tests to fail, possible because I don't have Stan set up properly on my PC?

══ Failed tests ════════════════════════════════════════════════════════════════
── Error ('test_cmdstan.R:6:3'): powerscale functions work for CmdStanFit ──────
Error: CmdStan path has not been set yet. See ?set_cmdstan_path.
Backtrace:
    ▆
 1. └─cmdstanr::cmdstan_model(stan_file = cmdstanr::write_stan_file(normal_example$model_code)) at test_cmdstan.R:6:3
 2.   └─cmdstanr::cmdstan_version()
 3.     └─cmdstanr:::stop_no_path()
── Error ('test_moment_matching.R:16:3'): moment matching is applied when specified and pareto-k is higher than threshold ──
Error: Please install the 'iwmm' package to use moment matching, available from https://github.com/topipa/iwmm
Backtrace:
     ▆
  1. ├─testthat::expect_true(...) at test_moment_matching.R:16:3
  2. │ └─testthat::quasi_label(enquo(object), label, arg = "object")
  3. │   └─rlang::eval_bare(expr, quo_get_env(quo))
  4. ├─priorsense:::get_powerscaling_details(...)
  5. ├─priorsense::powerscale(...)
  6. └─priorsense:::powerscale.default(...)
  7.   ├─priorsense::powerscale(...)
  8.   └─priorsense:::powerscale.priorsense_data(...)
  9.     └─priorsense:::require_package("iwmm", message = " to use moment matching, available from https://github.com/topipa/iwmm")
 10.       └─priorsense:::stop2(...)

[ FAIL 2 | WARN 0 | SKIP 0 | PASS 62 ]
Error: Test failures
Execution halted

1 error ✖ | 0 warnings ✔ | 6 notes ✖