### PR TITLE
fix: resolve multiple bugs in scale_draws(), ks_dist(), powerscale_plot_dens(), and log_prior_draws() doc (fixes #119)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 priorsense 1.2.0
 ---
++ Fix crash in `scale_draws()` when draws have weights
++ Fix incorrect fallback weights length in `ks_dist()` when x and y have different sample sizes
++ Fix error in density plot when using `trim` with `facet_rows = "variable"`
 + Allow either `variable` or `variables` to be accepted to subset
 + Fix issue with plotting of high Pareto-k values in quantities plot
 + Use new weighted ecdf from ggplot2, which fixes issue with previous implementation

--- a/R/additional_divergence_measures.R
+++ b/R/additional_divergence_measures.R
@@ -300,7 +300,7 @@ ks_dist <- function(x, y, x_weights = NULL, y_weights = NULL, ...) {
     x_weights <- rep(1, length(x))
   }
   if (is.null(y_weights)) {
-    y_weights <- rep(1, length(x))
+    y_weights <- rep(1, length(y))
   }
 
   ks <- stats::ks.test(

--- a/R/log_prior_draws.R
+++ b/R/log_prior_draws.R
@@ -1,6 +1,6 @@
 ##' Extract log prior draws
 ##'
-##' Extract log likelihood from fitted model and return as a draws
+##' Extract log prior from fitted model and return as a draws
 ##' object.
 ##'
 ##' @name log_prior_draws

--- a/R/plots.R
+++ b/R/plots.R
@@ -488,7 +488,7 @@ powerscale_plot_dens.powerscaled_sequence <-
               times = 2)
           )
         } else {
-          out <- out + ggh4x::facetted_pos_scales(
+          plot <- plot + ggh4x::facetted_pos_scales(
             x = rep(
               position_scales,
               each = 2

--- a/R/scale_draws.R
+++ b/R/scale_draws.R
@@ -16,8 +16,8 @@ scale_draws <- function(draws, center = TRUE, scale = TRUE, ...) {
 
   # remove weights
   if (!(is.null(wei))) {
-    base_draws <- posterior::mutate_variables(
-      base_draws,
+    draws <- posterior::mutate_variables(
+      draws,
       .log_weight = NULL)
   }
 

--- a/tests/testthat/test_div_measures.R
+++ b/tests/testthat/test_div_measures.R
@@ -16,3 +16,18 @@ test_that("divergence measures do not error", {
   }
 }
 )
+
+test_that("ks_dist handles unequal x/y lengths with y_weights = NULL", {
+
+  set.seed(42)
+  x <- rnorm(100)
+  y <- rnorm(50)
+
+  expect_no_error(priorsense:::ks_dist(x, y, y_weights = NULL))
+
+  result <- priorsense:::ks_dist(x, y, y_weights = NULL)
+  expect_named(result, "ks_dist.D")
+  expect_true(is.finite(result))
+
+}
+)

--- a/tests/testthat/test_scale_draws.R
+++ b/tests/testthat/test_scale_draws.R
@@ -8,3 +8,18 @@ test_that("scale draws returns draws object", {
 
 }
 )
+
+test_that("scale_draws works on weighted draws without error and preserves weights", {
+
+  ex_drw <- posterior::example_draws()
+  weights <- rep(1, posterior::ndraws(ex_drw))
+  weighted_drw <- posterior::weight_draws(ex_drw, weights = weights)
+
+  expect_no_error(scale_draws(weighted_drw))
+
+  result <- scale_draws(weighted_drw)
+  expect_s3_class(result, "draws")
+  expect_false(is.null(stats::weights(result)))
+
+}
+)


### PR DESCRIPTION
Fixes #119

## Changes

### `R/scale_draws.R`
Renamed undefined `base_draws` to `draws` in the weight-removal block. After
the `as_draws_matrix()` call the variable holding the draws is `draws`, not
`base_draws`, so the previous code always threw `Error: object 'base_draws'
not found` when called on any weighted draws object.

### `R/additional_divergence_measures.R`
Fixed `ks_dist()` fallback for `y_weights = NULL`. The default was
`rep(1, length(x))` but should be `rep(1, length(y))`. When `x` and `y`
differ in length this produced a wrong-length weights vector, causing either
a crash or silently incorrect results.

### `R/plots.R`
Fixed crash in `powerscale_plot_dens()` when `trim` is non-NULL and
`facet_rows = "variable"`. The trim branch was assigning to `out`, which is
never defined in that scope; the correct variable name is `plot`.

### `R/log_prior_draws.R`
Corrected copy-paste error in the roxygen title: changed
"Extract log likelihood from fitted model and return as a draws object."
to "Extract log prior from fitted model and return as a draws object."