### PR TITLE
Fix forwarding of custom log prior/likelihood names in powerscale_gradients

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ priorsense 1.2.0
 + Allow either `variable` or `variables` to be accepted to subset
 + Fix issue with plotting of high Pareto-k values in quantities plot
 + Use new weighted ecdf from ggplot2, which fixes issue with previous implementation
++ Fix `powerscale_gradients()` handling of custom `log_prior_name` and `log_lik_name` when starting from raw draws
 
 priorsense 1.1.1
 ---

--- a/R/create_priorsense_data.R
+++ b/R/create_priorsense_data.R
@@ -87,9 +87,9 @@ create_priorsense_data.default <- function(x,
 
   if (is.null(log_lik)) {
     if (is.null(fit)) {
-      log_lik <- log_lik_fn(x, ...)
+      log_lik <- log_lik_fn(x, log_lik_name = log_lik_name, ...)
     } else {
-      log_lik <- log_lik_fn(fit, ...)
+      log_lik <- log_lik_fn(fit, log_lik_name = log_lik_name, ...)
     }
   }
 

--- a/R/powerscale_gradients.R
+++ b/R/powerscale_gradients.R
@@ -44,9 +44,19 @@ powerscale_gradients <- function(x, ...) {
 ##' @export
 powerscale_gradients.default <- function(x, log_prior_name = "lprior", log_lik_name = "log_lik", ...) {
 
-  psd <- create_priorsense_data(x)
+  psd <- create_priorsense_data(
+    x,
+    log_prior_name = log_prior_name,
+    log_lik_name = log_lik_name,
+    ...
+  )
 
-  powerscale_gradients(psd, ...)
+  powerscale_gradients(
+    psd,
+    log_prior_name = log_prior_name,
+    log_lik_name = log_lik_name,
+    ...
+  )
 
   }
 
@@ -68,6 +78,8 @@ powerscale_gradients.priorsense_data <- function(x,
                                          scale = FALSE,
                                          prior_selection = NULL,
                                          likelihood_selection = NULL,
+                                         log_prior_name = "lprior",
+                                         log_lik_name = "log_lik",
                                          ...) {
 
   # input coercion
@@ -88,6 +100,8 @@ powerscale_gradients.priorsense_data <- function(x,
   if (!is.null(variable)) {
     variable <- as.character(variable)
   }
+  log_prior_name <- as.character(log_prior_name)
+  log_lik_name <- as.character(log_lik_name)
 
 
   # input checks
@@ -104,6 +118,8 @@ powerscale_gradients.priorsense_data <- function(x,
   checkmate::assertFunction(prediction, null.ok = TRUE)
   checkmate::assertFlag(scale)
   checkmate::assertFlag(moment_match)
+  checkmate::assertCharacter(log_prior_name, len = 1)
+  checkmate::assertCharacter(log_lik_name, len = 1)
 
   # extract the draws
   base_draws <- x$draws
@@ -176,6 +192,8 @@ powerscale_gradients.priorsense_data <- function(x,
       transform = transform,
       prediction = prediction,
       selection = selection[[comp]],
+      log_prior_name = log_prior_name,
+      log_lik_name = log_lik_name,
       ...
     )
 
@@ -191,6 +209,8 @@ powerscale_gradients.priorsense_data <- function(x,
       transform = transform,
       prediction = prediction,
       selection = selection[[comp]],
+      log_prior_name = log_prior_name,
+      log_lik_name = log_lik_name,
       ...
     )
 

--- a/tests/testthat/test_powerscale.R
+++ b/tests/testthat/test_powerscale.R
@@ -155,6 +155,50 @@ test_that("powerscale_sequence adapts alphas and keeps pareto-k low", {
 }
 )
 
+test_that("powerscale_gradients respects custom log component names", {
+  set.seed(10)
+  raw_draws <- posterior::as_draws_df(data.frame(
+    mu = rnorm(400),
+    lprior = rnorm(400),
+    log_lik = rnorm(400)
+  ))
+
+  renamed_draws <- raw_draws
+  posterior::variables(renamed_draws) <- c("mu", "custom_lprior", "custom_log_lik")
+
+  ref_prior <- powerscale_gradients(
+    raw_draws,
+    type = "quantities",
+    variable = "mu",
+    component = "prior"
+  )
+  got_prior <- powerscale_gradients(
+    renamed_draws,
+    type = "quantities",
+    variable = "mu",
+    component = "prior",
+    log_prior_name = "custom_lprior",
+    log_lik_name = "custom_log_lik"
+  )
+  ref_lik <- powerscale_gradients(
+    raw_draws,
+    type = "quantities",
+    variable = "mu",
+    component = "likelihood"
+  )
+  got_lik <- powerscale_gradients(
+    renamed_draws,
+    type = "quantities",
+    variable = "mu",
+    component = "likelihood",
+    log_prior_name = "custom_lprior",
+    log_lik_name = "custom_log_lik"
+  )
+
+  expect_equal(got_prior$quantities, ref_prior$quantities)
+  expect_equal(got_lik$quantities, ref_lik$quantities)
+})
+
 test_that("powerscale_sequence gives symmetric range", {
 
   lower_alpha <- 0.3


### PR DESCRIPTION
Fixes #121

This PR fixes a bug where custom log component variable names were not propagated through the `powerscale_gradients` workflow.

### Changes
- `powerscale_gradients.default` now forwards `log_prior_name` and `log_lik_name` to:
  - `create_priorsense_data(...)`
  - the subsequent `powerscale_gradients(...)` dispatch

- `powerscale_gradients.priorsense_data` now:
  - accepts `log_prior_name` and `log_lik_name`
  - validates/coerces them
  - forwards them to internal `powerscale(...)` calls

- `create_priorsense_data.default` now forwards `log_lik_name` to `log_lik_fn(...)` in both the `x` and `fit` branches.

### Why?
Previously, users with non-default log prior or log likelihood variable names could encounter missing-variable errors or incorrect behavior when calling `powerscale_gradients()` on raw draws. This PR ensures the custom variable names are consistently propagated through the entire workflow.