### PR TITLE
Perf: Optimize indexed variable expansion in plots (Resolves TODO)

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -802,10 +802,28 @@ powerscale_plot_quantities.powerscaled_sequence <-
     if (is.null(variable)) {
       variable <- posterior::variables(x$base_draws)
     } else {
-      # TODO: better way to handle e.g. "a" -> "a[1]", "a[2]"
-      variable <- posterior::variables(
-        posterior::subset_draws(x$base_draws, variable = variable)
-      )
+      # Efficient variable expansion avoiding heavy subset_draws operations
+      base_vars <- posterior::variables(x$base_draws)
+      
+      expanded_vars <- lapply(variable, function(v) {
+        # Keep variable if it matches exactly
+        if (v %in% base_vars) {
+          return(v)
+        }
+        
+        # Check for indexed variables (e.g., "a" -> "a[1]", "a[2]")
+        prefix <- paste0(v, "[")
+        indexed_matches <- base_vars[startsWith(base_vars, prefix)]
+        
+        if (length(indexed_matches) > 0) {
+          return(indexed_matches)
+        }
+        
+        # Return original string if no match (downstream handles errors)
+        return(v)
+      })
+      
+      variable <- unique(unlist(expanded_vars))
     }
 
     if (mcse) {


### PR DESCRIPTION
### Description
This PR addresses the explicit `TODO` in `R/plots.R` (around line 544) regarding the expansion of indexed variables (e.g., `"a"` -> `"a[1]", "a[2]"`).

### The Problem
The previous implementation relied on `posterior::subset_draws(x$base_draws, variable = variable)` just to extract the names of the expanded variables. For high-dimensional models (which are common in quantitative finance and large-scale Bayesian inference), calling `subset_draws()` involves heavy data subsetting and memory allocation, creating an unnecessary performance bottleneck during plotting.

### The Solution
Replaced the data-heavy `subset_draws()` operation with a lightweight string matching approach using `startsWith()`. 
* It extracts `base_vars` once.
* It checks for exact matches or prefix matches (e.g., `prefix <- paste0(v, "[")`).
* It returns the expanded strings without ever touching or copying the underlying posterior draws data.
